### PR TITLE
Allow for passing through stash options when opening a stash

### DIFF
--- a/crafting.lua
+++ b/crafting.lua
@@ -379,7 +379,7 @@ function openStash(data)
         exports[CodeMInv]:OpenStash(data.stash, 400000, 100)
     else
         TriggerEvent("inventory:client:SetCurrentStash", data.stash)
-        TriggerServerEvent("inventory:server:OpenInventory", "stash", data.stash)
+        TriggerServerEvent("inventory:server:OpenInventory", "stash", data.stash, data.stashOptions)
 	end
     lookEnt(data.coords)
 end


### PR DESCRIPTION
This PR adds the ability to pass stash options in when calling the openStash function. Existing function calls that don't pass the stashOptions should work without issue.