### PR TITLE
Add Quasar Inventory Support

### DIFF
--- a/frameworkCache.lua
+++ b/frameworkCache.lua
@@ -17,6 +17,7 @@ local Exports = {
     PSInv = "ps-inventory",
     CoreInv = "core_inventory",
     CodeMInv = "codem-inventory",
+    QSInv = "qs-inventory",
     OrigenInv = "origen_inventory",
     TgiannInv = "tgiann-inventory",
     JPRInv = "jpr-inventory",
@@ -126,6 +127,16 @@ local itemFunc = {
         cacheItem = function()
             local success, result = pcall(function()
                 return exports[Exports.OXInv]:Items()
+            end)
+            if success and result then
+                cache.Items = result
+            end
+        end,
+    },
+    {   script = Exports.QSInv,
+        cacheItem = function()
+            local success, result = pcall(function()
+                return exports[Exports.QSInv]:GetItemList()
             end)
             if success and result then
                 cache.Items = result

--- a/shared/coreloader.lua
+++ b/shared/coreloader.lua
@@ -10,12 +10,13 @@ OXLibExport, QBXExport, QBExport, ESXExport, OXCoreExport =
     Exports.ESXExport or "",
     Exports.OXCoreExport or ""
 
-OXInv, QBInv, PSInv, CoreInv, CodeMInv, OrigenInv, TgiannInv, JPRInv =
+OXInv, QBInv, PSInv, CoreInv, CodeMInv, QSInv, OrigenInv, TgiannInv, JPRInv =
     Exports.OXInv or "",
     Exports.QBInv or "",
     Exports.PSInv or "",
     Exports.CoreInv or "",
     Exports.CodeMInv or "",
+    Exports.QSInv or "",
     Exports.OrigenInv or "",
     Exports.TgiannInv or "",
     Exports.JPRInv or ""
@@ -99,6 +100,12 @@ else
                         Items[k].hunger = tempInfo.client.hunger
                         Items[k].thirst = tempInfo.client.thirst
                     end
+                end
+            end
+
+            if isStarted(QSInv) then
+                for k, v in pairs(Items) do
+                    Items[k].image = k..".png" -- Set default image
                 end
             end
         end)

--- a/shared/itemcontrol.lua
+++ b/shared/itemcontrol.lua
@@ -129,6 +129,124 @@ local InvFunc = {
             end,
     },
 
+    {   invName = QSInv,
+        removeItem =
+            function(src, item, remamount)
+                exports[QSInv]:RemoveItem(src, item, remamount)
+            end,
+        addItem =
+            function(src, item, amountToAdd, info, slot)
+                exports[QSInv]:AddItem(src, item, amountToAdd, slot, info)
+            end,
+        setItemMetadata =
+            function(data, src)
+                exports[QSInv]:SetItemMetadata(src, data.slot, data.metadata)
+            end,
+        hasItem =
+            function(item, amount, src, invCache)
+                local count = 0
+                if invCache then
+                    for _, itemData in pairs(invCache) do
+                        if itemData and itemData.name == item then
+                            count = count + (itemData.amount or itemData.count or 0)
+                        end
+                    end
+                else
+                    if src then
+                        count = exports[QSInv]:GetItemTotalAmount(src, item)
+                    else
+                        local items = exports[QSInv]:Search(item)
+                        for _, v in pairs(items) do
+                            count = count + (v.amount or v.count or 0)
+                        end
+                    end
+                end
+                return count >= amount, count
+            end,
+        canCarry =
+            function(itemTable, src)
+                local resultTable = {}
+                for k, v in pairs(itemTable) do
+                    resultTable[k] = exports[QSInv]:CanCarryItem(src, k, v)
+                end
+                return resultTable
+            end,
+        getMaxInvWeight =
+            function()
+                return InventoryWeight
+            end,
+        getCurrentInvWeight =
+            function(src)
+                local weight = 0
+                local itemcheck = getPlayerInv(src)
+                if itemcheck then
+                    for _, v in pairs(itemcheck) do
+                        weight = weight + ((v.weight * (v.amount or v.count or 1)) or 0)
+                    end
+                end
+                return weight
+            end,
+        getPlayerInv =
+            function(src)
+                if src then
+                    return exports[QSInv]:GetInventory(src)
+                else
+                    return exports[QSInv]:getUserInventory()
+                end
+            end,
+        invImg =
+            function(item)
+                return "nui://"..QSInv.."/html/images/"..(Items[item].image or "")
+            end,
+        openShop =
+            function(name, label, items)
+                --
+            end,
+        serverOpenShop = function(shopName)
+            --
+        end,
+        registerShop =
+            function(name, label, items, society)
+                exports[QSInv]:RegisterShop(name, {
+                    name = label,
+                    items = items,
+                    account = society,
+                })
+            end,
+        openStash =
+            function(data)
+                TriggerEvent("inventory:client:SetCurrentStash", data.stash)
+                TriggerServerEvent("inventory:server:OpenInventory", "stash", data.stash, {
+                    maxweight = data.maxweight,
+                    slots = data.slots,
+                })
+            end,
+        clearStash =
+            function(stashId)
+                exports[QSInv]:ClearOtherInventory(stashId)
+            end,
+        getStash =
+            function(stashId)
+                return exports[QSInv]:GetStashItems(stashId)
+            end,
+        stashEditMetadata =
+            function(stash, slot, metadata)
+                --
+            end,
+        stashAddItem =
+            function(stashItems, stashName, items)
+                --
+            end,
+        stashRemoveItem =
+            function(stashItems, stashName, items)
+                --
+            end,
+        registerStash =
+            function(name, label, slots, weight, owner, coords)
+                exports[QSInv]:RegisterStash(name, slots, weight)
+            end,
+    },
+
     {   invName = CoreInv,
         removeItem =
             function(src, item, remamount)
@@ -2500,7 +2618,7 @@ end
 --- local hasAll, details = stashhasItem(currentStashItems, { iron = 2, wood = 5 })
 --- ```
 function stashhasItem(stashItems, items, amount)
-    local invs = { OXInv, CoreInv, CodeMInv, OrigenInv, TgiannInv, JPRInv, QBInv, PSInv, RSGInv }
+    local invs = { OXInv, CoreInv, CodeMInv, QSInv, OrigenInv, TgiannInv, JPRInv, QBInv, PSInv, RSGInv }
     local foundInv = ""
 
     for _, inv in ipairs(invs) do


### PR DESCRIPTION
Using the following [Documentation](https://docs.quasar-store.com/scripts/compact-inventory/commands-and-exports), I've attempted to expand Jim Bridge's compatibility to also include Quasar Inventory Support.

Truthfully the QB-Core functions have been working well for my server, I just wanted to try to expand the Bridge so that my console could stop being spammed with "Falling back to core functions!".

This is also a requested feature: https://github.com/jimathy/jim_bridge/issues/65